### PR TITLE
Directly use the api key

### DIFF
--- a/lib/googlemaps.js
+++ b/lib/googlemaps.js
@@ -16,7 +16,8 @@ var _config = {
   'stagger-time': 200,
   'encode-polylines': true,
   'proxy': null,
-  'google-private-key': null
+  'google-private-key': null,
+  'key': null
 };
 
 
@@ -449,6 +450,10 @@ function buildUrl(path, args) {
     var signature = signer.update(path).digest('base64');
     signature = signature.replace(/\+/g,'-').replace(/\//g,'_');
     path += "&signature=" + signature;
+    return path;
+  } else if (config('key')) {
+    path = path + "?" + qs.stringify(args);
+    path += "&key=" + config('key');
     return path;
   } else {
     return path + "?" + qs.stringify(args);

--- a/lib/googlemaps.js
+++ b/lib/googlemaps.js
@@ -17,7 +17,7 @@ var _config = {
   'encode-polylines': true,
   'proxy': null,
   'google-private-key': null,
-  'key': null
+  'google-api-key': null
 };
 
 
@@ -451,9 +451,9 @@ function buildUrl(path, args) {
     signature = signature.replace(/\+/g,'-').replace(/\//g,'_');
     path += "&signature=" + signature;
     return path;
-  } else if (config('key')) {
+  } else if (config('google-api-key')) {
     path = path + "?" + qs.stringify(args);
-    path += "&key=" + config('key');
+    path += "&key=" + config('google-api-key');
     return path;
   } else {
     return path + "?" + qs.stringify(args);


### PR DESCRIPTION
Add the ability to set an api key directly rather than using a client id and secret.

I verified this works locally by setting the key and making a static maps request.