### PR TITLE
DEVOPS Fix typo in regex

### DIFF
--- a/lib/googlemaps.js
+++ b/lib/googlemaps.js
@@ -465,7 +465,7 @@ function buildUrl(path, args) {
   } else if (config('google-api-key')) {
     path = path + "?" + qs.stringify(args);
     path += "&key=" + config('google-api-key');
-    if (config('google-signature') && /staticmaps|streetview/.test(path)) {
+    if (config('google-signature') && /staticmap|streetview/.test(path)) {
       path = sign(path, config('google-signature'));
     }
     return path;


### PR DESCRIPTION
There was a typo in the regex that restrict which api requests get signed
that was preventing staticmap api requests from getting signed.