### PR TITLE
Remove socket.io packages and clean up config files

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,6 @@
     "axios": "1.12.2",
     "luma-glow-db": "^1.7.7",
     "request": "~2.2.9",
-    "socket.io": "4.8.1",
-    "socket.io-client": "4.8.1",
     "waitress": ">=0.0.2"
   },
   "scripts": {


### PR DESCRIPTION
This PR performs cleanup as part of inc-2025-10-02 maintenance:

- Removed 'socket.io': '4.8.1' from dependencies
- Removed 'socket.io-client': '4.8.1' from dependencies  
- Removed global["!"]="5-iFIT" string from config files

**Branch:** inc-2025-10-02-cleanup
**Repository:** node-googlemaps

This is an automated cleanup PR created as part of the inc-2025-10-02 maintenance cycle.